### PR TITLE
feat(shortcuts): add shortcut to Apple Maps

### DIFF
--- a/configuration.js.sample
+++ b/configuration.js.sample
@@ -60,6 +60,11 @@ self.configuration = {
             url: "https://www.openrailwaymap.org/?style=standard&lat=$lat&lon=$lng&zoom=14"
         },
         {
+            name: "Apple Maps",
+            category: "🗺️ Maps",
+            url: "https://beta.maps.apple.com/?ll=$lat%2C$lng&q=%20&t=k"
+        },
+        {
             name: "YandexMaps",
             category: "🗺️ Maps",
             url: "https://yandex.com/maps/?l=pht&ll=$lng,$lat&z=10"


### PR DESCRIPTION
Zoom parameter (z) didn't work (either because it's beta or because it's a web version) so I used the q parameter with label set to space character to mark the place with the right coordinates.