### PR TITLE
feat(shortcuts): add shortcut for SunCalc

### DIFF
--- a/configuration.js.sample
+++ b/configuration.js.sample
@@ -70,6 +70,12 @@ self.configuration = {
             url: "https://shademap.app/@$lat,$lng,15z"
         },
         {
+            name: "SunCalc",
+            category: "🗺️ Maps",
+            url: "https://www.suncalc.org/#/$lat,$lng,15/$date/$time/1/1",
+            precision: 4,
+        },     
+        {
             name: "EO Browser",
             category: "🗺️ Maps",
             url: "https://apps.sentinel-hub.com/eo-browser/?zoom=15&lat=$lat&lng=$lng"

--- a/configuration.js.sample
+++ b/configuration.js.sample
@@ -77,7 +77,7 @@ self.configuration = {
         {
             name: "SunCalc",
             category: "🗺️ Maps",
-            url: "https://www.suncalc.org/#/$lat,$lng,15/$date/$time/1/1",
+            url: "https://www.suncalc.org/#/$lat,$lng,15/null/null/null/1",
             precision: 4,
         },     
         {

--- a/src/services/shortcuts.js
+++ b/src/services/shortcuts.js
@@ -50,9 +50,12 @@ class Shortcuts {
      */
     open(url, precision = null) {
         const coords = this.router.getCoordinates();
+        const date = new Date();
         url = url
             .replace("$lat", precision != null ? coords.lat.toFixed(precision) : coords.lat)
-            .replace("$lng", precision != null ? coords.lng.toFixed(precision) : coords.lng);
+            .replace("$lng", precision != null ? coords.lng.toFixed(precision) : coords.lng)
+            .replace("$date", date.toISOString().split('T')[0].replaceAll('-', '.'))
+            .replace("$time", date.toTimeString().slice(0,5));
         
         window.open(url, '_blank');
     }

--- a/src/services/shortcuts.js
+++ b/src/services/shortcuts.js
@@ -50,12 +50,9 @@ class Shortcuts {
      */
     open(url, precision = null) {
         const coords = this.router.getCoordinates();
-        const date = new Date();
         url = url
             .replace("$lat", precision != null ? coords.lat.toFixed(precision) : coords.lat)
-            .replace("$lng", precision != null ? coords.lng.toFixed(precision) : coords.lng)
-            .replace("$date", date.toISOString().split('T')[0].replaceAll('-', '.'))
-            .replace("$time", date.toTimeString().slice(0,5));
+            .replace("$lng", precision != null ? coords.lng.toFixed(precision) : coords.lng);
         
         window.open(url, '_blank');
     }


### PR DESCRIPTION
I swear this is the last one ;). In this case I had to introduce two additional parameters - date and time. Without them SunCalc displays the error message and then ignores zoom settings. I know that it would be better not to add them but I couldn't find any other solution. 