### PR TITLE
feat(shortcuts): add shortcut to PeakVisor

### DIFF
--- a/configuration.js.sample
+++ b/configuration.js.sample
@@ -70,6 +70,12 @@ self.configuration = {
             url: "https://yandex.com/maps/?l=pht&ll=$lng,$lat&z=10"
         },
         {
+            name: "PeakVisor",
+            category: "🗺️ Maps",
+            url: "https://peakvisor.com/panorama.html?lat=$lat&lng=$lng",
+            precision: 7,
+        },
+        {
             name: "ShadeMap",
             category: "🗺️ Maps",
             url: "https://shademap.app/@$lat,$lng,15z"


### PR DESCRIPTION
I found this article: https://www.bellingcat.com/resources/2023/07/13/more-than-mountaineering-using-peakvisor-for-geolocation/ and I thought that it would be great to have a shortcut to this site in Avoc.