### PR TITLE
Use https for bing module to avoid blocking

### DIFF
--- a/src/maps/bing.js
+++ b/src/maps/bing.js
@@ -82,7 +82,7 @@ class Bing {
 
 define("maps/bing", [
     "module",
-    "http://www.bing.com/api/maps/mapcontrol"
+    "https://www.bing.com/api/maps/mapcontrol"
 ], function() {
     // Workaround for a known Bing Maps V8 Web Control error
     window.sj_evt = undefined;


### PR DESCRIPTION
The use of http protocol caused deployments using https to fail, even if the Bing module wasn't used.