### PR TITLE
Fix router location address

### DIFF
--- a/src/core/router.js
+++ b/src/core/router.js
@@ -9,7 +9,7 @@ class Router {
         this.db = db;
         this.allowedParams = module.config().allowedParams;
         this.defaultCoords = module.config().defaultCoords;
-        this.locationAddress = window.location.protocol + "//" + window.location.pathname;
+        this.locationAddress = window.location.origin == "null" ? "" : window.location.origin + window.location.pathname;
     }
 
     /**


### PR DESCRIPTION
Previously there was a bug in how the router location address was calculated causing it to fail when deployed. 

It failed with a [SecurityError](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState#securityerror) [DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) from the [history pushState](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) call 

This fix is tested for Chrome and Firefox (the latter needs the ternery check for "null" returned by window.location.origin when loading a local file)